### PR TITLE
Add a custom shouldPullToRefresh function

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ What will the pull to refresh trigger? You can return a promise. Defaults to `wi
 
 The resistance function, accepts one parameter, must return a number, capping at 1. Defaults to `t => Math.min(1, t / 2.5)`
 
+➡ `shouldPullToRefresh` (function)
+
+What condition should be met for pullToRefresh to trigger? Defaults to `!window.scrollY`
+
 ➡ `passive` (boolean)
 
 This value will be passed as `{ passive: true|false }` to `touchmove` listeners if passive-handlers are supported. Defaults to `false`

--- a/dist/pulltorefresh.js
+++ b/dist/pulltorefresh.js
@@ -33,6 +33,7 @@ var _defaults = {
   onInit: function () {},
   onRefresh: function () { return location.reload(); },
   resistanceFunction: function (t) { return Math.min(1, t / 2.5); },
+  shouldPullToRefresh: function () { return !window.scrollY; },
 };
 
 var pullStartY = null;
@@ -101,9 +102,10 @@ function _setupEvents() {
   }
 
   function _onTouchStart(e) {
+    var shouldPullToRefresh = _SETTINGS.shouldPullToRefresh;
     var triggerElement = _SETTINGS.triggerElement;
 
-    if (!window.scrollY) {
+    if (shouldPullToRefresh()) {
       pullStartY = e.touches[0].screenY;
     }
 
@@ -119,15 +121,16 @@ function _setupEvents() {
   }
 
   function _onTouchMove(e) {
-    var ptrElement = _SETTINGS.ptrElement;
-    var resistanceFunction = _SETTINGS.resistanceFunction;
-    var distMax = _SETTINGS.distMax;
-    var distThreshold = _SETTINGS.distThreshold;
     var cssProp = _SETTINGS.cssProp;
     var classPrefix = _SETTINGS.classPrefix;
+    var distMax = _SETTINGS.distMax;
+    var distThreshold = _SETTINGS.distThreshold;
+    var ptrElement = _SETTINGS.ptrElement;
+    var resistanceFunction = _SETTINGS.resistanceFunction;
+    var shouldPullToRefresh = _SETTINGS.shouldPullToRefresh;
 
     if (!pullStartY) {
-      if (!window.scrollY) {
+      if (shouldPullToRefresh()) {
         pullStartY = e.touches[0].screenY;
       }
     } else {
@@ -135,7 +138,7 @@ function _setupEvents() {
     }
 
     if (!_enable || _state === 'refreshing') {
-      if (!window.scrollY && pullStartY < pullMoveY) {
+      if (shouldPullToRefresh() && pullStartY < pullMoveY) {
         e.preventDefault();
       }
 
@@ -222,8 +225,9 @@ function _setupEvents() {
   function _onScroll() {
     var mainElement = _SETTINGS.mainElement;
     var classPrefix = _SETTINGS.classPrefix;
+    var shouldPullToRefresh = _SETTINGS.shouldPullToRefresh;
 
-    mainElement.classList.toggle((classPrefix + "top"), !window.scrollY);
+    mainElement.classList.toggle((classPrefix + "top"), shouldPullToRefresh());
   }
 
   window.addEventListener('touchend', _onTouchEnd);

--- a/src/pulltorefresh.js
+++ b/src/pulltorefresh.js
@@ -26,6 +26,7 @@ const _defaults = {
   onInit: () => {},
   onRefresh: () => location.reload(),
   resistanceFunction: t => Math.min(1, t / 2.5),
+  shouldPullToRefresh: () => !window.scrollY,
 };
 
 let pullStartY = null;
@@ -94,9 +95,9 @@ function _setupEvents() {
   }
 
   function _onTouchStart(e) {
-    const { triggerElement } = _SETTINGS;
+    const { shouldPullToRefresh, triggerElement } = _SETTINGS;
 
-    if (!window.scrollY) {
+    if (shouldPullToRefresh()) {
       pullStartY = e.touches[0].screenY;
     }
 
@@ -113,11 +114,12 @@ function _setupEvents() {
 
   function _onTouchMove(e) {
     const {
-      ptrElement, resistanceFunction, distMax, distThreshold, cssProp, classPrefix,
+      cssProp, classPrefix, distMax, distThreshold, ptrElement, resistanceFunction,
+      shouldPullToRefresh,
     } = _SETTINGS;
 
     if (!pullStartY) {
-      if (!window.scrollY) {
+      if (shouldPullToRefresh()) {
         pullStartY = e.touches[0].screenY;
       }
     } else {
@@ -125,7 +127,7 @@ function _setupEvents() {
     }
 
     if (!_enable || _state === 'refreshing') {
-      if (!window.scrollY && pullStartY < pullMoveY) {
+      if (shouldPullToRefresh() && pullStartY < pullMoveY) {
         e.preventDefault();
       }
 
@@ -207,10 +209,10 @@ function _setupEvents() {
 
   function _onScroll() {
     const {
-      mainElement, classPrefix,
+      mainElement, classPrefix, shouldPullToRefresh,
     } = _SETTINGS;
 
-    mainElement.classList.toggle(`${classPrefix}top`, !window.scrollY);
+    mainElement.classList.toggle(`${classPrefix}top`, shouldPullToRefresh());
   }
 
   window.addEventListener('touchend', _onTouchEnd);


### PR DESCRIPTION
### What is this
We ran into an issue where when displaying a large list when trying to back scroll up, we would perform the scrollToRefresh action instead of scrolling up.

In our case `window.scrollY` was always returning 0, because of a `height: 100%` that we're using in order to display a toolbar at the top and a navbar at the bottom.

I couldn't really see a good example in the tests for a way to add tests around this, but if you have any ideas I'd be happy to add some.


