### PR TITLE
Added 'Repository' property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "test": "testem ci",
     "dev_test": "testem"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BoxFactura/pulltorefresh.js.git"
+  },
   "files": [
     "dist/*.js"
   ],


### PR DESCRIPTION
To make it easier to find this repository I've added the [repository](https://docs.npmjs.com/files/package.json#repository) property to `package.json` so that you can use the [npm repo](https://docs.npmjs.com/cli/repo) command to open it.
This should also make the repository show up on the [npmjs.com](https://www.npmjs.com/package/pulltorefreshjs) page.