### PR TITLE
Set !mainElement.scrollTop as default shouldPullToRefresh condition

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -25,7 +25,7 @@ const _defaults = {
   onInit: () => {},
   onRefresh: () => location.reload(),
   resistanceFunction: t => Math.min(1, t / 2.5),
-  shouldPullToRefresh: () => !window.scrollY,
+  shouldPullToRefresh: () => !document.querySelector(this.mainElement).scrollTop,
 };
 
 const _methods = ['mainElement', 'ptrElement', 'triggerElement'];


### PR DESCRIPTION
Set !mainElement.scrollTop as default shouldPullToRefresh condition. It is to simplify the start for new devs with PTR.