### PR TITLE
Destroy handler properly

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -21,8 +21,7 @@ export default {
   init(options = {}) {
     const handler = _setupHandler(options);
 
-    // store offset for later unsubscription
-    handler.offset = _shared.handlers.push(handler) - 1;
+    _shared.handlers.push(handler);
 
     return handler;
   },

--- a/src/lib/setup.js
+++ b/src/lib/setup.js
@@ -38,7 +38,8 @@ export default options => {
     clearTimeout(_shared.timeout);
 
     // remove handler from shared state
-    _shared.handlers.splice(_handler.offset, 1);
+    const offset = _shared.handlers.indexOf(_handler);
+    _shared.handlers.splice(offset, 1);
   };
 
   return _handler;


### PR DESCRIPTION
This commit changes destroy behavior to find target handler offset on destroy time. Storing handler offset on initialization is unreliable as it might be changed later.

For example, let's assume that there's 3 instances a, b, c.

1. Init a
```
_shared.handlers: [a]
a.offset = 0;
```

2. Init b
```
_shared.handlers: [a, b]
a.offset = 0;
b.offset = 1;
```

3. Destroy a
```
_shared.handlers: [b]
b.offset = 1;
```

4. Init c
```
_shared.handlers: [b, c]
b.offset = 1;
c.offset = 1;
```

5. Now trying to destroy b will destroy c at offset 1 instead. And you get
```
_shared.handlers: [b]
```

It is quite common situation for PWA where routing is handled in client-side.
