### PR TITLE
Use pointer events when available instead of touch events

### DIFF
--- a/src/demos/basic-pointer-events.pug
+++ b/src/demos/basic-pointer-events.pug
@@ -1,0 +1,10 @@
+extend ../_/layout
+
+block run
+  script.
+    /* global PullToRefresh */
+    PullToRefresh.setPointerEventsMode(true);
+    PullToRefresh.init({
+      mainElement: '#main',
+      onRefresh: function() { alert('refresh') }
+    });

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -2,7 +2,7 @@ import _ptr from './api';
 import _shared from './shared';
 
 const screenY = function screenY(event) {
-  if (_shared.supportsPointerEvents) {
+  if (_shared.pointerEventsEnabled && _shared.supportsPointerEvents) {
     return event.screenY;
   }
   return event.touches[0].screenY;
@@ -126,18 +126,17 @@ export default () => {
     _shared.dist = _shared.distResisted = 0;
   }
 
+  const _passiveSettings = _shared.supportsPassive
+    ? { passive: _shared.passive || false }
+    : undefined;
+
   function _onScroll() {
     if (_el) {
       _el.mainElement.classList.toggle(`${_el.classPrefix}top`, _el.shouldPullToRefresh());
     }
   }
 
-  const _passiveSettings = _shared.supportsPassive
-    ? { passive: _shared.passive || false }
-    : undefined;
-
-
-  if (_shared.supportsPointerEvents) {
+  if (_shared.pointerEventsEnabled && _shared.supportsPointerEvents) {
     window.addEventListener('pointerup', _onTouchEnd);
     window.addEventListener('pointerdown', _onTouchStart);
     window.addEventListener('pointermove', _onTouchMove, _passiveSettings);
@@ -146,7 +145,6 @@ export default () => {
     window.addEventListener('touchstart', _onTouchStart);
     window.addEventListener('touchmove', _onTouchMove, _passiveSettings);
   }
-
   window.addEventListener('scroll', _onScroll);
 
   return {
@@ -156,8 +154,7 @@ export default () => {
     onScroll: _onScroll,
 
     destroy() {
-      // Teardown event listeners
-      if (_shared.supportsPointerEvents) {
+      if (_shared.pointerEventsEnabled && _shared.supportsPointerEvents) {
         window.removeEventListener('pointerdown', _onTouchStart);
         window.removeEventListener('pointerup', _onTouchEnd);
         window.removeEventListener('pointermove', _onTouchMove, _passiveSettings);
@@ -166,6 +163,7 @@ export default () => {
         window.removeEventListener('touchend', _onTouchEnd);
         window.removeEventListener('touchmove', _onTouchMove, _passiveSettings);
       }
+
       window.removeEventListener('scroll', _onScroll);
     },
   };

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -8,6 +8,9 @@ export default {
   setPassiveMode(isPassive) {
     _shared.passive = isPassive;
   },
+  setPointerEventsMode(isEnabled) {
+    _shared.pointerEventsEnabled = isEnabled;
+  },
   destroyAll() {
     if (_shared.events) {
       _shared.events.destroy();

--- a/src/lib/shared.js
+++ b/src/lib/shared.js
@@ -9,6 +9,7 @@ const _shared = {
   timeout: null,
   distResisted: 0,
   supportsPassive: false,
+  supportsPointerEvents: !!window.PointerEvent,
 };
 
 try {

--- a/tests/e2e/cases/basic-pointer-events.test.js
+++ b/tests/e2e/cases/basic-pointer-events.test.js
@@ -1,0 +1,12 @@
+import { pullToRefresh, hasMinHeight, isUnmounted } from '../helpers';
+
+/* global fixture, test */
+
+fixture('Basic test with pointer events')
+  .page('http://localhost:8080/basic-pointer-events.html');
+
+test('use `mainElement` for prepending before a given element', async () => {
+  await isUnmounted();
+  await pullToRefresh('body', 100, 200);
+  await hasMinHeight();
+});


### PR DESCRIPTION
Why would you want to do that?

Performance issues, mostly. Pointer events work better with scrolling. As a quote from [this page](https://blogs.windows.com/msedgedev/2017/12/07/better-precision-touchpad-experience-ptp-pointer-events/)

> Scrolling with PTPs in Microsoft Edge will never cause scroll jank since Pointer Event handlers (unlike mousewheel and Touch Event handlers) are designed so that they cannot block scrolling.

It was explained to me recently here: https://github.com/nolanlawson/pinafore/pull/1146

You might want to add an option to enable this (and not have it by default). 

Note that it also enables the behaviour in not touch environments (which can be a feature). It is also easy to disable.