### PR TITLE
Check if event is cancelable before calling preventDefault

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -44,7 +44,7 @@ export default () => {
     }
 
     if (_shared.state === 'refreshing') {
-      if (_el.shouldPullToRefresh() && _shared.pullStartY < _shared.pullMoveY) {
+      if (_el.shouldPullToRefresh() && _shared.pullStartY < _shared.pullMoveY && e.cancelable) {
         e.preventDefault();
       }
 
@@ -64,7 +64,9 @@ export default () => {
     _shared.distExtra = _shared.dist - _el.distIgnore;
 
     if (_shared.distExtra > 0) {
-      e.preventDefault();
+      if(e.cancelable) {
+        e.preventDefault();
+      }
 
       _el.ptrElement.style[_el.cssProp] = `${_shared.distResisted}px`;
 

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -44,7 +44,7 @@ export default () => {
     }
 
     if (_shared.state === 'refreshing') {
-      if (_el.shouldPullToRefresh() && _shared.pullStartY < _shared.pullMoveY && e.cancelable) {
+      if (e.cancelable && _el.shouldPullToRefresh() && _shared.pullStartY < _shared.pullMoveY) {
         e.preventDefault();
       }
 
@@ -64,7 +64,7 @@ export default () => {
     _shared.distExtra = _shared.dist - _el.distIgnore;
 
     if (_shared.distExtra > 0) {
-      if(e.cancelable) {
+      if (e.cancelable) {
         e.preventDefault();
       }
 


### PR DESCRIPTION
Was getting console errors because sometimes preventDefault was being called when it was not cancelable.

(Got this on chrome emulator of iphone 5 / SE)
[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.